### PR TITLE
small but effecive UI improvements

### DIFF
--- a/app/components/Header.vue
+++ b/app/components/Header.vue
@@ -2,7 +2,7 @@
 import { useRoute } from 'vue-router'
 const route = useRoute()
 
-const includeDisclaimer = ['/portfolio-cases/responsive-product-catalogue']
+const includeDisclaimer = []
 console.log(route.path)
 </script>
 

--- a/app/components/Menu.vue
+++ b/app/components/Menu.vue
@@ -20,7 +20,7 @@ const buttonNames = [
 <template>
   <!-- Top panel -->
   <div
-    class="top-panel flex relative z-50 bg-transparent justify-between items-center w-full max-w-95/100 md:mb-6 mx-auto"
+    class="top-panel flex relative z-50 bg-transparent justify-between items-center w-full px-3 sm:px-4 mt-3 lg:mt-6 md:px-6 md:mb-6 mx-auto"
   >
     <NuxtLink to="/" class="logo-link">
       <div
@@ -46,7 +46,7 @@ const buttonNames = [
     </button>
 
     <!-- Desktop menu -->
-    <div class="menu hidden md:flex gap-2 w-full max-w-95/100 justify-end">
+    <div class="menu hidden md:flex gap-2 w-full justify-end">
       <div v-for="(item, i) in buttonNames" :key="i" classs="menu-item relative">
         <NuxtLink
           :to="item.link"

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -7,7 +7,7 @@
     <Header />
     <div class="content w-full flex flex-1">
       <div
-        class="container flex w-full h-full max-w-[1150px] flex flex-col items-center px-2 sm:px-3 md:px-4 mx-auto"
+        class="container flex w-full h-full flex flex-col items-center px-3 sm:px-4 md:px-6 mx-auto"
       >
         <NuxtPage />
       </div>

--- a/app/pages/about.vue
+++ b/app/pages/about.vue
@@ -11,8 +11,8 @@
           more stable and complete.
         </p>
 
-        <div class="photo max-h-[200px] max-w-[150px]">
-          <img src="/img/portrait.png" alt="my photo" />
+        <div class="photo max-h-[200px] max-w-[150px] aspect-[16/9]">
+          <img src="/img/portrait.png" height="200" width="150" alt="my photo" />
         </div>
       </div>
       <div class="item flex flex-col! gap-1">

--- a/app/pages/portfolio-cases/responsive-product-catalogue.vue
+++ b/app/pages/portfolio-cases/responsive-product-catalogue.vue
@@ -29,7 +29,7 @@ import Catalogue from '~/components/portfolio/Catalogue.vue'
             >
           </p>
           <div
-            class="overflow-hidden [grid-area:demo] rounded-md border border-gray-200 dark:border-gray-400 p-1 mb-auto max-w-[300px]"
+            class="overflow-hidden [grid-area:demo] rounded-md border border-gray-200 dark:border-gray-400 p-1 mb-auto max-w-[300px] aspect-[16/9]"
           >
             <img
               class="rounded-md w-full h-auto object-fill object-center"

--- a/app/pages/portfolio-cases/responsive-product-catalogue.vue
+++ b/app/pages/portfolio-cases/responsive-product-catalogue.vue
@@ -7,7 +7,7 @@ import Catalogue from '~/components/portfolio/Catalogue.vue'
     <NuxtLink to="/portfolio" class="navigation mr-auto before:content-['<<'] before:mr-1">
       Back to portfolio</NuxtLink
     >
-    <section id="case-details" class="max-w-5xl mx-auto py-16">
+    <section id="case-details" class="mx-auto py-16">
       <div class="space-y-10">
         <!-- Header -->
         <h2 class="text-3xl md:text-4xl font-semibold tracking-tight">Responsive Product Grid</h2>

--- a/app/pages/portfolio-cases/responsive-product-catalogue.vue
+++ b/app/pages/portfolio-cases/responsive-product-catalogue.vue
@@ -7,7 +7,7 @@ import Catalogue from '~/components/portfolio/Catalogue.vue'
     <NuxtLink to="/portfolio" class="navigation mr-auto before:content-['<<'] before:mr-1">
       Back to portfolio</NuxtLink
     >
-    <section id="case-details" class="max-w-5xl mx-auto px-4 py-16">
+    <section id="case-details" class="max-w-5xl mx-auto py-16">
       <div class="space-y-10">
         <!-- Header -->
         <h2 class="text-3xl md:text-4xl font-semibold tracking-tight">Responsive Product Grid</h2>

--- a/app/pages/portfolio.vue
+++ b/app/pages/portfolio.vue
@@ -80,7 +80,7 @@ const recommendations = [
               /></div
             ></NuxtLink>
             <div class="case-description sm:self-center">
-              <h3 class="hidden sm:block text-xl mb-3 text-center">{{ item.title }}</h3>
+              <h3 class="hidden sm:block text-2xl mb-3 text-center">{{ item.title }}</h3>
               <p>
                 {{ item.description
                 }}<NuxtLink

--- a/app/pages/portfolio.vue
+++ b/app/pages/portfolio.vue
@@ -67,8 +67,10 @@ const recommendations = [
       </h2>
       <div v-for="item in cases" :key="item.title" class="cases flex flex-col gap-2">
         <div class="case">
-          <h3 class="block sm:hidden text-xl mb-3 text-center">{{ item.title }}</h3>
-          <div class="case-preview-card pb-6 mb-4 flex flex-col sm:flex-row gap-4">
+          <h3 class="block sm:hidden text-xl mb-3 text-left">{{ item.title }}</h3>
+          <div
+            class="case-preview-card pb-6 mb-4 flex flex-col sm:flex-row gap-4 md:gap-6 lg:gap-8"
+          >
             <NuxtLink class="case-link cursor-pointer" :to="item.demoLink"
             ><div
               class="image-container max-w-[400px] m-auto sm:max-w-none sm:w-[300px] md:w-[400px] lg:w-[500px] rounded-sm overflow-hidden"
@@ -79,9 +81,9 @@ const recommendations = [
                 class="portfolio-case-img mask-b-from-54% mask-b-to-100%"
               /></div
             ></NuxtLink>
-            <div class="case-description sm:self-center">
-              <h3 class="hidden sm:block text-2xl mb-3 text-center">{{ item.title }}</h3>
-              <p>
+            <div class="case-description sm:self-center mb-auto">
+              <h3 class="hidden sm:block text-2xl mb-3 text-left">{{ item.title }}</h3>
+              <p class="text-left!">
                 {{ item.description
                 }}<NuxtLink
                   class="case-link underline block w-full mt-2 mb-2 cursor-pointer"

--- a/app/pages/portfolio.vue
+++ b/app/pages/portfolio.vue
@@ -73,12 +73,12 @@ const recommendations = [
           >
             <NuxtLink class="case-link cursor-pointer" :to="item.demoLink"
             ><div
-              class="image-container max-w-[400px] m-auto sm:max-w-none sm:w-[300px] md:w-[400px] lg:w-[500px] rounded-sm overflow-hidden"
+              class="image-container max-w-[400px] m-auto sm:max-w-none sm:w-[300px] md:w-[400px] lg:w-[450px] aspect-[5/4] rounded-sm overflow-hidden"
             >
               <img
                 :src="item.demoImg"
                 :alt="item.title"
-                class="portfolio-case-img mask-b-from-54% mask-b-to-100%"
+                class="portfolio-case-img mask-b-from-24% mask-b-to-90%"
               /></div
             ></NuxtLink>
             <div class="case-description sm:self-center mb-auto">


### PR DESCRIPTION
- menu and content aligning 
- add more space around the page content

before
<img width="1356" height="783" alt="Screenshot 2026-03-23 at 11 21 03" src="https://github.com/user-attachments/assets/8f5080ad-15ad-4512-9881-ccf6bb47a965" />
<img width="1356" height="783" alt="Screenshot 2026-03-23 at 11 21 13" src="https://github.com/user-attachments/assets/8e7814b4-f26d-44fa-86bd-9f307cf4939f" />

after
<img width="1356" height="783" alt="Screenshot 2026-03-23 at 11 25 00" src="https://github.com/user-attachments/assets/d197a910-b561-4ee9-ab01-51071c1573ed" />
<img width="1356" height="783" alt="Screenshot 2026-03-23 at 11 25 07" src="https://github.com/user-attachments/assets/7b795681-4d3d-47dc-9116-3aba8789c99e" />
